### PR TITLE
Add Python converter and moves.json

### DIFF
--- a/convert_moves.py
+++ b/convert_moves.py
@@ -1,0 +1,84 @@
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def sanitize_ts(ts_path: Path) -> Path:
+    text = ts_path.read_text()
+    text = re.sub(r"export const Moves:.*?=", "globalThis.Moves =", text, 1)
+    text = text.replace(" as ID", "")
+    text = text.replace(" as unknown as ActiveMove", "")
+    text = re.sub(r"!([\.\[])", r"\1", text)
+    text = text.replace("!++", "++")
+    tmp = tempfile.NamedTemporaryFile("w+", suffix=".js", delete=False)
+    tmp.write(text)
+    tmp.flush()
+    return Path(tmp.name)
+
+
+def run_node(js_input: Path, output_json: Path):
+    node_script = """
+const fs = require('fs');
+const vm = require('vm');
+const [,, jsPath, outPath] = process.argv;
+const code = fs.readFileSync(jsPath, 'utf8');
+const context = {};
+vm.runInNewContext(code, context);
+const Moves = context.Moves;
+function sanitize(obj) {
+  if (Array.isArray(obj)) return obj.map(sanitize);
+  if (obj && typeof obj === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (typeof v === 'function') continue;
+      out[k] = sanitize(v);
+    }
+    return out;
+  }
+  return obj;
+}
+const plain = {};
+for (const [id, data] of Object.entries(Moves)) {
+  if (!data.gen || data.gen <= 3) {
+    plain[id] = sanitize({
+      id,
+      name: data.name,
+      type: data.type,
+      category: data.category,
+      basePower: data.basePower,
+      accuracy: data.accuracy,
+      pp: data.pp,
+      priority: data.priority,
+      flags: data.flags,
+    });
+  }
+}
+fs.writeFileSync(outPath, JSON.stringify(plain, null, 2));
+"""
+    with tempfile.NamedTemporaryFile("w+", suffix=".js", delete=False) as helper:
+        helper.write(node_script)
+        helper.flush()
+        subprocess.run(
+            ["node", helper.name, js_input.as_posix(), output_json.as_posix()],
+            check=True,
+        )
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent
+    ts_file = repo_root / "3gen_env_Showdown" / "moves.ts"
+    out_dir = repo_root / "data"
+    out_dir.mkdir(exist_ok=True)
+    out_file = out_dir / "moves.json"
+    sanitized = sanitize_ts(ts_file)
+    try:
+        run_node(sanitized, out_file)
+    finally:
+        sanitized.unlink(missing_ok=True)
+    print(f"Wrote {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/moves.json
+++ b/data/moves.json
@@ -1,0 +1,319 @@
+{
+  "absorb": {
+    "id": "absorb",
+    "pp": 20
+  },
+  "acid": {
+    "id": "acid"
+  },
+  "ancientpower": {
+    "id": "ancientpower",
+    "flags": {
+      "contact": 1,
+      "protect": 1,
+      "mirror": 1,
+      "metronome": 1
+    }
+  },
+  "assist": {
+    "id": "assist",
+    "flags": {
+      "metronome": 1,
+      "noassist": 1,
+      "nosleeptalk": 1
+    }
+  },
+  "astonish": {
+    "id": "astonish"
+  },
+  "beatup": {
+    "id": "beatup"
+  },
+  "bide": {
+    "id": "bide",
+    "accuracy": 100,
+    "priority": 0
+  },
+  "blizzard": {
+    "id": "blizzard"
+  },
+  "brickbreak": {
+    "id": "brickbreak"
+  },
+  "charge": {
+    "id": "charge"
+  },
+  "conversion": {
+    "id": "conversion"
+  },
+  "counter": {
+    "id": "counter"
+  },
+  "covet": {
+    "id": "covet",
+    "flags": {
+      "protect": 1,
+      "mirror": 1,
+      "noassist": 1
+    }
+  },
+  "crunch": {
+    "id": "crunch"
+  },
+  "dig": {
+    "id": "dig",
+    "basePower": 60
+  },
+  "disable": {
+    "id": "disable",
+    "accuracy": 55,
+    "flags": {
+      "protect": 1,
+      "mirror": 1,
+      "bypasssub": 1,
+      "metronome": 1
+    }
+  },
+  "dive": {
+    "id": "dive",
+    "basePower": 60
+  },
+  "doomdesire": {
+    "id": "doomdesire"
+  },
+  "encore": {
+    "id": "encore"
+  },
+  "extrasensory": {
+    "id": "extrasensory"
+  },
+  "fakeout": {
+    "id": "fakeout",
+    "flags": {
+      "protect": 1,
+      "mirror": 1,
+      "metronome": 1
+    }
+  },
+  "feintattack": {
+    "id": "feintattack",
+    "flags": {
+      "protect": 1,
+      "mirror": 1,
+      "metronome": 1
+    }
+  },
+  "flail": {
+    "id": "flail"
+  },
+  "flash": {
+    "id": "flash",
+    "accuracy": 70
+  },
+  "fly": {
+    "id": "fly",
+    "basePower": 70
+  },
+  "followme": {
+    "id": "followme"
+  },
+  "foresight": {
+    "id": "foresight",
+    "accuracy": 100
+  },
+  "furycutter": {
+    "id": "furycutter"
+  },
+  "gigadrain": {
+    "id": "gigadrain",
+    "pp": 5
+  },
+  "glare": {
+    "id": "glare"
+  },
+  "haze": {
+    "id": "haze"
+  },
+  "hiddenpower": {
+    "id": "hiddenpower",
+    "category": "Physical"
+  },
+  "highjumpkick": {
+    "id": "highjumpkick",
+    "basePower": 85
+  },
+  "hypnosis": {
+    "id": "hypnosis",
+    "accuracy": 60
+  },
+  "jumpkick": {
+    "id": "jumpkick",
+    "basePower": 70
+  },
+  "leafblade": {
+    "id": "leafblade",
+    "basePower": 70
+  },
+  "lockon": {
+    "id": "lockon",
+    "accuracy": 100
+  },
+  "megadrain": {
+    "id": "megadrain",
+    "pp": 10
+  },
+  "memento": {
+    "id": "memento",
+    "accuracy": true
+  },
+  "mindreader": {
+    "id": "mindreader",
+    "accuracy": 100
+  },
+  "mimic": {
+    "id": "mimic",
+    "flags": {
+      "protect": 1,
+      "bypasssub": 1,
+      "allyanim": 1,
+      "failencore": 1,
+      "noassist": 1,
+      "failmimic": 1
+    }
+  },
+  "mirrorcoat": {
+    "id": "mirrorcoat"
+  },
+  "mirrormove": {
+    "id": "mirrormove",
+    "flags": {
+      "metronome": 1,
+      "failencore": 1,
+      "nosleeptalk": 1,
+      "noassist": 1
+    }
+  },
+  "naturepower": {
+    "id": "naturepower",
+    "accuracy": 95
+  },
+  "needlearm": {
+    "id": "needlearm"
+  },
+  "nightmare": {
+    "id": "nightmare",
+    "accuracy": true
+  },
+  "odorsleuth": {
+    "id": "odorsleuth",
+    "accuracy": 100
+  },
+  "outrage": {
+    "id": "outrage",
+    "basePower": 90
+  },
+  "overheat": {
+    "id": "overheat",
+    "flags": {
+      "contact": 1,
+      "protect": 1,
+      "mirror": 1,
+      "metronome": 1
+    }
+  },
+  "petaldance": {
+    "id": "petaldance",
+    "basePower": 70
+  },
+  "recover": {
+    "id": "recover",
+    "pp": 20
+  },
+  "reversal": {
+    "id": "reversal"
+  },
+  "rocksmash": {
+    "id": "rocksmash",
+    "basePower": 20
+  },
+  "sketch": {
+    "id": "sketch",
+    "flags": {
+      "bypasssub": 1,
+      "failencore": 1,
+      "noassist": 1,
+      "failmimic": 1,
+      "nosketch": 1
+    }
+  },
+  "sleeptalk": {
+    "id": "sleeptalk"
+  },
+  "spite": {
+    "id": "spite"
+  },
+  "stockpile": {
+    "id": "stockpile",
+    "pp": 10
+  },
+  "struggle": {
+    "id": "struggle",
+    "accuracy": 100,
+    "flags": {
+      "contact": 1,
+      "protect": 1,
+      "noassist": 1,
+      "failencore": 1,
+      "failmimic": 1,
+      "nosketch": 1
+    }
+  },
+  "surf": {
+    "id": "surf"
+  },
+  "taunt": {
+    "id": "taunt",
+    "flags": {
+      "protect": 1,
+      "bypasssub": 1,
+      "metronome": 1
+    }
+  },
+  "teeterdance": {
+    "id": "teeterdance",
+    "flags": {
+      "protect": 1,
+      "metronome": 1
+    }
+  },
+  "tickle": {
+    "id": "tickle",
+    "flags": {
+      "protect": 1,
+      "reflectable": 1,
+      "mirror": 1,
+      "bypasssub": 1,
+      "metronome": 1
+    }
+  },
+  "uproar": {
+    "id": "uproar"
+  },
+  "vinewhip": {
+    "id": "vinewhip",
+    "pp": 10
+  },
+  "volttackle": {
+    "id": "volttackle"
+  },
+  "waterfall": {
+    "id": "waterfall"
+  },
+  "weatherball": {
+    "id": "weatherball"
+  },
+  "zapcannon": {
+    "id": "zapcannon",
+    "basePower": 100
+  }
+}

--- a/move.py
+++ b/move.py
@@ -1,7 +1,12 @@
+import json
+from pathlib import Path
+
+
 class Move:
     """
     Represents a Pokémon move in Gen 3 battle simulation, with PP management.
     """
+
     def __init__(
         self,
         name: str,
@@ -20,6 +25,7 @@ class Move:
         self.priority = priority
         self.max_pp = max_pp
         self.current_pp = max_pp
+        self.metadata: dict = {}
 
     def use_pp(self):
         """Consume 1 PP; raise if no PP remains."""
@@ -32,3 +38,24 @@ class Move:
             f"<Move {self.name}: {self.type} {self.category}, Power={self.power}, "
             f"Acc={self.accuracy}%, PP={self.current_pp}/{self.max_pp}, Pri={self.priority}>"
         )
+
+
+def load_moves(json_path: Path | str = None) -> dict[str, "Move"]:
+    """Load move metadata from JSON into Move objects."""
+    if json_path is None:
+        json_path = Path(__file__).parent.parent / "data" / "moves.json"
+    data = json.loads(Path(json_path).read_text())
+    registry: dict[str, Move] = {}
+    for name, meta in data.items():
+        mv = Move(
+            name=meta.get("name", name),
+            move_type=meta.get("type", "Normal"),
+            power=meta.get("basePower", 0) or 0,
+            category=meta.get("category", "Physical"),
+            accuracy=meta.get("accuracy", 100),
+            priority=meta.get("priority", 0),
+            max_pp=meta.get("pp", 1),
+        )
+        mv.metadata = meta
+        registry[name] = mv
+    return registry


### PR DESCRIPTION
## Summary
- add `convert_moves.py` to produce a JSON representation of `moves.ts`
- generate `data/moves.json` containing Gen 3 move metadata
- extend `Move` class with metadata handling
- implement `load_moves()` helper

## Testing
- `python convert_moves.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844550110f08325a592fab44d3d5228