### PR TITLE
Fix ability loading path

### DIFF
--- a/ability.py
+++ b/ability.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
 def load_abilities(json_path: Path | str = None) -> dict[str, type]:
     """Load abilities metadata from JSON and build subclasses dynamically."""
     if json_path is None:
-        json_path = Path(__file__).parent.parent / 'data' / 'abilities.json'
+        # Default to the abilities.json file located alongside this module
+        json_path = Path(__file__).with_name('abilities.json')
     data = json.loads(Path(json_path).read_text())
     registry: dict[str, type] = {}
     for name, meta in data.items():


### PR DESCRIPTION
## Summary
- ensure ability metadata loads from the correct JSON file by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import ability
print('abilities count', len(ability.abilities_map))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68445427fee88325af6cc8b9a1744faf