### PR TITLE
Fix Rest move and switching logic

### DIFF
--- a/battle_env/battle.py
+++ b/battle_env/battle.py
@@ -75,8 +75,15 @@ class Battle:
                         mon.remove_volatile(v)
         if action1.get('type') == 'switch':
             self.team1.switch(action1['index'])
-            self.team1.active().ability.on_switch_in(self)
-            self.team1.active().item.on_switch_in(self)
+            mon = self.team1.active()
+            if isinstance(mon.ability, str):
+                cls = abilities_map.get(mon.ability, Ability)
+                mon.ability = cls(mon)
+            if isinstance(mon.item, str) or mon.item is None:
+                itm = items_map.get(mon.item, Item)
+                mon.item = itm(mon)
+            mon.ability.on_switch_in(self)
+            mon.item.on_switch_in(self)
             opp_haz = self.team1.hazards
             if 'spikes' in opp_haz:
                 layers = opp_haz['spikes']
@@ -88,8 +95,15 @@ class Battle:
 
         if action2.get('type') == 'switch':
             self.team2.switch(action2['index'])
-            self.team2.active().ability.on_switch_in(self)
-            self.team2.active().item.on_switch_in(self)
+            mon = self.team2.active()
+            if isinstance(mon.ability, str):
+                cls = abilities_map.get(mon.ability, Ability)
+                mon.ability = cls(mon)
+            if isinstance(mon.item, str) or mon.item is None:
+                itm = items_map.get(mon.item, Item)
+                mon.item = itm(mon)
+            mon.ability.on_switch_in(self)
+            mon.item.on_switch_in(self)
             opp_haz = self.team2.hazards
             if 'spikes' in opp_haz:
                 layers = opp_haz['spikes']
@@ -203,8 +217,14 @@ class Battle:
                 dmg //= 2
             if def_team.screens.get('lightscreen') and move.category == 'Special':
                 dmg //= 2
-            target.apply_damage(dmg)
-            self.log(f"{attacker.name} used {move.name} and dealt {dmg} damage to {target.name}!")
+            if move.name.lower() == 'rest':
+                attacker.heal(attacker.stats['hp'])
+                attacker.heal_status()
+                attacker.set_status('slp')
+                self.log(f"{attacker.name} used Rest and fell asleep!")
+            else:
+                target.apply_damage(dmg)
+                self.log(f"{attacker.name} used {move.name} and dealt {dmg} damage to {target.name}!")
 
             # on_after_damage hooks
             attacker.ability.on_after_damage(move, attacker, target, dmg, self)

--- a/battle_env/damage.py
+++ b/battle_env/damage.py
@@ -57,6 +57,11 @@ def get_damage_range(initial_damage, attacker, defender, move, is_crit=False, we
     """
     Calculates the final damage range based on the full Gen 3 formula.
     """
+    # Moves with no base power (e.g. status moves like Rest) should never deal
+    # damage.  Early exit before applying any modifiers to avoid returning a
+    # minimum of 1 damage.
+    if move.get('power', 0) == 0:
+        return 0, 0
     # --- New: Handle Immunities Early ---
     # Before any calculation, check if the move is immune. If so, damage is 0.
     type_effectiveness = get_type_effectiveness(move['type'], defender.get('types', []))

--- a/battle_env/team_builder.py
+++ b/battle_env/team_builder.py
@@ -17,6 +17,7 @@ def parse_showdown(text: str, moves_db: dict[str, Pokemon]|None=None) -> Team:
     """Parse a Showdown-exported team string into a Team."""
     if moves_db is None:
         moves_db = load_moves()
+    canon_map = { _canon(name): mv for name, mv in moves_db.items() }
     blocks = [b.strip() for b in text.strip().split('\n\n') if b.strip()]
     team_members = []
     for block in blocks:
@@ -58,9 +59,11 @@ def parse_showdown(text: str, moves_db: dict[str, Pokemon]|None=None) -> Team:
             elif line.endswith('Nature'):
                 nature = line.split()[0]
             elif line.startswith('-'):
-                move_name = line[1:].strip().lower()
-                if move_name in moves_db:
-                    moves.append(deepcopy(moves_db[move_name]))
+                move_name = line[1:].strip()
+                canon = _canon(move_name)
+                mv = canon_map.get(canon)
+                if mv:
+                    moves.append(deepcopy(mv))
         base_stats = get_base_stats(name)
         types = get_pokemon_types(name)
         p = Pokemon(name=name, level=level, types=types, base_stats=base_stats,


### PR DESCRIPTION
## Summary
- avoid damage for zero-power moves (Rest)
- make Rest heal and inflict sleep
- instantiate abilities/items when switching
- parse moves using canonical names

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from battle_env.team_builder import parse_showdown
from battle_env.moves_loader import load_moves
from battle_env.battle import Battle
from pathlib import Path
moves_db = load_moves()
team1 = parse_showdown(Path('team1.txt').read_text(), moves_db)
team2 = parse_showdown(Path('team2.txt').read_text(), moves_db)
battle = Battle(team1, team2)
battle.start()
action1 = {'type': 'move', 'index': 0}
action2 = {'type': 'move', 'index': 0}
battle.play_turn(action1, action2)
battle.play_turn({'type':'switch','index':1},{'type':'move','index':1})
print('Active1:', team1.active().name, 'HP', team1.active().current_hp)
print('Moves2:', [m.name for m in team2.members[0].moves])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68448d4d295483258789c9e5a89c72b4